### PR TITLE
Address initial PR feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ _This is intended for internal HashiCorp use only_
         - workflow_dispatch
     jobs:
     create-branch:
-        runs-on: [linux, small]
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: hashicorp/actions-create-release-branch@v1
+            - uses: hashicorp/actions-create-release-branch@v2
                 with:
                 token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
     ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _This is intended for internal HashiCorp use only_
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: hashicorp/actions-create-release-branch@v2
+            - uses: hashicorp/actions-create-release-branch@v1
                 with:
                 token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
     ```

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ runs:
         echo "name=release/${{ steps.get-current-version.outputs.minor }}.x" | tee -a "$GITHUB_OUTPUT"
         echo "version=${{ steps.get-current-version.outputs.minor }}.0" | tee -a "$GITHUB_OUTPUT"
     - name: Check if release branch already exists
+      shell: bash
       run: |
         git ls-remote --heads --exit-code origin ${{ steps.set-release-branch-name-and-version.outputs.name }} && \
         { \

--- a/action.yml
+++ b/action.yml
@@ -32,19 +32,24 @@ runs:
       run: |
         echo "name=release/${{ steps.get-current-version.outputs.minor }}.x" | tee -a "$GITHUB_OUTPUT"
         echo "version=${{ steps.get-current-version.outputs.minor }}.0" | tee -a "$GITHUB_OUTPUT"
+    - name: Check if release branch already exists
+      run: |
+        git ls-remote --heads --exit-code origin ${{ steps.set-release-branch-name-and-version.outputs.name }} && \
+        { \
+          echo "Cannot create branch ${{ steps.set-release-branch-name-and-version.outputs.name }} because it already exists" ;
+          echo "Please bump version file manually" ;
+          exit 1 ;
+        }
     - name: Create new release branch
       id: create-release-branch
       shell: bash
       run: |
-        git ls-remote --heads --exit-code origin ${{ steps.set-release-branch-name-and-version.outputs.name }} || \
-        { \
-          git config --global user.name "Rel Eng team" ;
-          git config --global user.email "team-rel-eng@hashicorp.com" ;
-          git fetch origin && git checkout main ;
-          git checkout -B ${{ steps.set-release-branch-name-and-version.outputs.name }} ;
-          git push origin ${{ steps.set-release-branch-name-and-version.outputs.name }} ;
-          git checkout main ;
-        }
+        git config --global user.name "Rel Eng team"
+        git config --global user.email "team-rel-eng@hashicorp.com"
+        git fetch origin && git checkout main
+        git checkout -B ${{ steps.set-release-branch-name-and-version.outputs.name }}
+        git push origin ${{ steps.set-release-branch-name-and-version.outputs.name }}
+        git checkout main
     - uses: hashicorp/action-setup-bob@v1
       with:
         github-token: ${{ inputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Check if release branch already exists
       shell: bash
       run: |
-        git ls-remote --heads --exit-code origin ${{ steps.set-release-branch-name-and-version.outputs.name }} && \
+        test -z "$(git ls-remote --heads origin ${{ steps.set-release-branch-name-and-version.outputs.name }})" || \
         { \
           echo "Cannot create branch ${{ steps.set-release-branch-name-and-version.outputs.name }} because it already exists" ;
           echo "Please bump version file manually" ;

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v3
     - name: Get current version
       id: get-current-version
       shell: bash


### PR DESCRIPTION
Context: https://hashicorp.slack.com/archives/C03UM8KMU72/p1674659371658499?thread_ts=1674567557.584299&cid=C03UM8KMU72

Commits are separate to address points #1 (move checkout to live within the action) and #2 (fail if branch already exists), I have not touched point #3 (use ``steps.get-current-version.outputs.full`` as the``-version`` param  for ``bob update version``), as it appears it is needed to keep ``.0`` at the end of the bumped version.

Also created a test PR in the CRT Hello World repo to be able to run this: https://github.com/hashicorp/crt-core-helloworld/pull/95